### PR TITLE
Add MCP-OS quickstart tutorial

### DIFF
--- a/docs/concepts/mcp-os.mdx
+++ b/docs/concepts/mcp-os.mdx
@@ -1,0 +1,68 @@
+---
+title: "MCP-OS"
+description: "Model Context Protocol Operating System powered by an AI kernel"
+---
+
+# MCP-OS
+
+The **Model Context Protocol Operating System (MCP-OS)** is a post-app operating system concept where the user interface and application logic are generated in real time by a large language model. Rather than shipping fully implemented applications, MCP-OS relies on a thin rendering shell that communicates with an AI kernel through a well defined protocol.
+
+## System architecture
+
+MCP-OS is composed of three core components:
+
+1. **MCP-Kernel** – a stateless large language model that receives requests and generates protocol compliant responses.
+2. **MCP-Shell** – a lightweight renderer that captures user input, formats protocol requests and displays the declarative UI tree returned by the kernel.
+3. **Model Context Protocol (MCP)** – the structured message format used for all communication between shell and kernel.
+
+These pieces form a continuous loop: the shell packages user actions as an MCP request, the kernel reasons about the current context, and the resulting MCP response describes the next UI state to display.
+
+## Model Context Protocol
+
+An MCP **request** contains the user's context, the current UI state and an event describing their action:
+
+```json
+{
+  "protocol_version": "1.0",
+  "session_id": "sid_example_1234",
+  "user_context": { "name": "Alex" },
+  "current_ui_state": {
+    "view_id": "view_home",
+    "component_tree_hash": "abcd1234"
+  },
+  "event": {
+    "type": "click",
+    "target": { "component_id": "desktop_icon_documents" }
+  }
+}
+```
+
+The **response** from the kernel is a declarative UI tree describing what should be displayed next:
+
+```json
+{
+  "protocol_version": "1.0",
+  "session_id": "sid_example_1234",
+  "directive": "REPLACE_VIEW",
+  "new_ui_state": {
+    "view_id": "view_documents",
+    "component_tree": {
+      "component": "Window",
+      "children": [ { "component": "ListView" } ]
+    }
+  }
+}
+```
+
+## Example workflow
+
+1. The user clicks an icon. The shell emits an MCP request with the click event.
+2. The kernel processes the request, reasons about the context and generates a response describing a new view.
+3. The shell renders the new view exactly as described.
+4. Any further interaction restarts the loop with a new request.
+
+This architecture eliminates hardcoded application logic and allows the operating system to adapt the UI to the user's current needs.
+
+## Challenges
+
+While promising, MCP-OS must address latency, state consistency, operating costs and security. The protocol forms the foundation for tackling these issues by enforcing a clear separation between the rendering shell and the reasoning kernel.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,12 +42,13 @@
               "concepts/agents",
               "concepts/messages",
               "concepts/state",
-              "concepts/tools"
+              "concepts/tools",
+              "concepts/mcp-os"
             ]
           },
           {
             "group": "Tutorials",
-            "pages": ["tutorials/cursor", "tutorials/debugging"]
+            "pages": ["tutorials/cursor", "tutorials/debugging", "tutorials/smithery-cli", "tutorials/mcp-os-quickstart"]
           },
           {
             "group": "Development",

--- a/docs/tutorials/mcp-os-quickstart.mdx
+++ b/docs/tutorials/mcp-os-quickstart.mdx
@@ -1,0 +1,59 @@
+---
+title: "MCP-OS Quickstart"
+description: "End to end example using Smithery CLI and AG-UI client"
+---
+
+This tutorial walks through building a minimal MCP‑OS proof of concept. We will
+run an MCP server with the
+**[Smithery CLI](https://github.com/smithery-ai/cli)** and connect to it with a
+small AG‑UI client.
+
+## 1. Install prerequisites
+
+- [Node.js](https://nodejs.org/) **v18+**
+- A Smithery account and API key
+
+## 2. Start a sample MCP server
+
+Install the Smithery CLI and launch a server:
+
+```bash
+npx @smithery/cli login
+npx @smithery/cli install mcp-obsidian --client claude
+npx @smithery/cli run mcp-obsidian
+```
+
+The output prints the local MCP endpoint URL. Export it for the client to use:
+
+```bash
+export MCP_SERVER_URL=http://localhost:8080/mcp
+```
+
+## 3. Run the MCP shell examples
+
+Two minimal clients are provided to connect to your server.
+
+### TypeScript
+
+Run the `mcp-shell.ts` script with **ts-node**:
+
+```bash
+npx ts-node typescript-sdk/examples/mcp-shell.ts
+```
+
+### Python
+
+Alternatively you can use the Python example:
+
+```bash
+python python-sdk/examples/mcp_shell.py
+```
+
+Both scripts send a greeting message to the server and stream back MCP events.
+These events describe the UI state that an MCP‑OS shell would render.
+
+## 4. Next steps
+
+Modify the example to forward user input from your own interface and render the
+returned component tree. This forms the basis of an MCP‑OS style workflow where
+the UI is generated on demand by the server.

--- a/docs/tutorials/smithery-cli.mdx
+++ b/docs/tutorials/smithery-cli.mdx
@@ -1,0 +1,70 @@
+---
+title: "Smithery CLI"
+description: "Install and run Model Context Protocol servers with the Smithery CLI"
+---
+
+# Overview
+
+The [Smithery CLI](https://github.com/smithery-ai/cli) provides a quick way to install and manage Model Context Protocol (MCP) servers. It works with any AG-UI compatible client and is a fast way to explore different server implementations.
+
+This guide walks through installing the CLI, grabbing a sample server, and running it end to end.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) **v18 or later**
+- A Smithery account and API key
+
+## 1. Install the CLI
+
+You can run the tool directly via `npx`:
+
+```bash
+npx @smithery/cli --help
+```
+
+The first run downloads the CLI and shows the available commands.
+
+## 2. Login
+
+Authenticate the CLI so it can fetch servers from the registry:
+
+```bash
+npx @smithery/cli login
+```
+
+Follow the prompt and paste your API key.
+
+## 3. Install a server
+
+Smithery hosts many prebuilt MCP servers. For example, install the `mcp-obsidian` server for the `claude` client:
+
+```bash
+npx @smithery/cli install mcp-obsidian --client claude
+```
+
+You can list available clients and installed servers with:
+
+```bash
+npx @smithery/cli list clients
+npx @smithery/cli list servers --client claude
+```
+
+## 4. Run the server
+
+Start the server with any required configuration:
+
+```bash
+npx @smithery/cli run mcp-obsidian --config '{"vaultPath":"/path/to/vault"}'
+```
+
+The CLI launches the server locally. You will see the MCP endpoint URL in the output.
+
+## 5. Connect via AG-UI
+
+Once the server is running you can point any AG-UI compatible client or application at the MCP endpoint. The server streams events that AG-UI can render or forward into your own interface.
+
+This completes the full loop: user input flows through AG-UI to the MCP server and the responses stream back for display.
+
+## Next steps
+
+Explore other Smithery servers or build your own. The CLI's `dev` command lets you hot‑reload custom servers and even open a playground to test them interactively.

--- a/python-sdk/examples/mcp_shell.py
+++ b/python-sdk/examples/mcp_shell.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import json
+import requests
+
+
+def main() -> None:
+    url = os.environ.get("MCP_SERVER_URL")
+    if not url:
+        print("Set MCP_SERVER_URL to the running Smithery server endpoint", file=sys.stderr)
+        sys.exit(1)
+
+    payload = {
+        "messages": [
+            {"id": "1", "role": "user", "content": "hello"}
+        ]
+    }
+
+    with requests.post(url, json=payload, stream=True, headers={"Accept": "text/event-stream"}) as resp:
+        resp.raise_for_status()
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            try:
+                data = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                print(line.decode("utf-8"))
+                continue
+            print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/typescript-sdk/examples/mcp-shell.ts
+++ b/typescript-sdk/examples/mcp-shell.ts
@@ -1,0 +1,23 @@
+import { HttpAgent } from "../packages/client/src/agent";
+
+async function main() {
+  const url = process.env.MCP_SERVER_URL;
+  if (!url) {
+    console.error("Set MCP_SERVER_URL to the running Smithery server endpoint");
+    process.exit(1);
+  }
+
+  const agent = new HttpAgent({ url });
+  agent.messages = [
+    { id: "1", role: "user", content: "hello" },
+  ];
+
+  for await (const event of agent.runAgent()) {
+    console.log(event);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add quickstart example showing how to run an MCP server with Smithery CLI and connect via AG‑UI
- include a simple HttpAgent script under `typescript-sdk/examples`
- register the new tutorial in docs navigation
- document Python example for connecting to an MCP server
- link directly to the Smithery CLI repo in the quickstart

## Testing
- `pytest -q python-sdk/tests`
- `pnpm test` *(fails: `google/protobuf/struct.proto` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590c048ba883278da8d85974ff041e